### PR TITLE
Rework scheduler for birthday reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Daily stats schedule:
 11:00 Asia/Yekaterinburg
 ```
 
+Daily birthday reminders schedule:
+```bash
+06:01 UTC
+11:01 Asia/Yekaterinburg
+```
+
 How to run:
 ```bash
 python3 -m pip install -r requirements.txt

--- a/handlers/birthday_reminders.py
+++ b/handlers/birthday_reminders.py
@@ -2,10 +2,10 @@ import datetime
 import logging
 import os
 
-from telegram import Update
 from telegram.ext import ContextTypes
 
 from db.database import get_db_users, get_reminder_status, reset_user_reminders, update_reminder
+from handlers.global_stats import STATS_CHAT_IDS_KEY
 from models.user_manager import get_closest_birthday
 from util.util import markdown_escape
 
@@ -13,19 +13,35 @@ from util.util import markdown_escape
 logger = logging.getLogger(__name__)
 ADVANCE_REMINDER_TYPES = ['reminder_14_days', 'reminder_7_days', 'reminder_1_days']
 
+# Birthday reminders broadcast to every group chat the bot is active in. We reuse the
+# chat registry that already powers /stats (handlers/global_stats.py) instead of
+# keeping a second, redundant list of "known" chats in sync with it.
+KNOWN_GROUP_CHAT_IDS_KEY = STATS_CHAT_IDS_KEY
 
-async def process_birthday_reminders(update: Update, context: ContextTypes) -> None:
-    chat = update.effective_chat
-    if chat is None or getattr(chat, 'type', None) not in {'group', 'supergroup'}:
-        return
 
-    last_birthday_check = context.chat_data.get('last_birthday_check')
-    if last_birthday_check is not None and (datetime.datetime.now() - last_birthday_check).days < 1:
-        return
+async def _broadcast(bot, chat_ids: list[int], text: str) -> None:
+    for chat_id in chat_ids:
+        try:
+            await bot.send_message(chat_id=chat_id, text=text, parse_mode='MarkdownV2')
+        except Exception as e:
+            logger.warning(f"Failed to send birthday reminder to chat_id={chat_id}: {e}")
 
-    context.chat_data['last_birthday_check'] = datetime.datetime.now()
-    logger.info("Birthdays are not checked, checking birthdays")
+
+async def send_daily_birthday_reminders(context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Daily job_queue task: checks every user's birthday once a day and broadcasts
+    reminders/congratulations to every group chat the bot is registered in.
+
+    Replaces the old behaviour where reminders only fired as a side effect of someone
+    sending a message in the group (see issue #7): on a quiet day, the actual
+    "happy birthday" message on the day itself could be silently skipped, because
+    get_closest_birthday() rolls over to next year as soon as the date is in the past.
+    """
     db_path = os.getenv('DB_PATH')
+    chat_ids = sorted(chat_id for chat_id in context.bot_data.get(KNOWN_GROUP_CHAT_IDS_KEY, set()) if chat_id < 0)
+    if not chat_ids:
+        logger.info("No chats registered for birthday reminders")
+        return
+
     users = get_db_users(db_path)
     for user in users:
         if user.birthday is None:
@@ -36,24 +52,27 @@ async def process_birthday_reminders(update: Update, context: ContextTypes) -> N
             reset_user_reminders(db_path, user.user_id, ADVANCE_REMINDER_TYPES)
         if days_until_birthday != 0:
             reset_user_reminders(db_path, user.user_id, ['birthday_today'])
-        if days_until_birthday in [14, 7, 1]:
+
+        if days_until_birthday in (14, 7, 1):
             reminder_type = f"reminder_{days_until_birthday}_days"
             if get_reminder_status(db_path, user.user_id, user.tg_username, reminder_type):
                 continue
-            await chat.send_message(
+            await _broadcast(
+                context.bot,
+                chat_ids,
                 f"❗❗❗ ВСЕМ ВНИМАНИЕ ЭТО НЕ УЧЕБНАЯ ТРЕВОГА ❗❗❗\n"
                 f"Скоро день рождения у {markdown_escape(user.tg_username)}\n"
                 f"*Дата:* {markdown_escape(user.birthday)}\n"
                 f"*Желаемые подарки:* {markdown_escape(user.wishlist_url)}\n",
-                parse_mode='MarkdownV2'
             )
             update_reminder(db_path, user.user_id, user.tg_username, reminder_type)
         elif days_until_birthday == 0:
             if get_reminder_status(db_path, user.user_id, user.tg_username, 'birthday_today'):
                 continue
-            await chat.send_message(
+            await _broadcast(
+                context.bot,
+                chat_ids,
                 f"❗❗❗ ВСЕМ ВНИМАНИЕ ЭТО АВТОМАТИЧЕСКОЕ ПОЗДРАВЛЕНИЕ ❗❗❗\n"
                 f"🎉 🎉 🎉  С ДНЕМ РОЖДЕНИЯ {markdown_escape(user.tg_username)}  🎉 🎉 🎉\n",
-                parse_mode='MarkdownV2'
             )
             update_reminder(db_path, user.user_id, user.tg_username, 'birthday_today')

--- a/handlers/message_handler.py
+++ b/handlers/message_handler.py
@@ -8,7 +8,6 @@ from dotenv import load_dotenv
 from telegram import Update
 from telegram.ext import ContextTypes
 from db.database import get_db_users, update_username
-from handlers.birthday_reminders import process_birthday_reminders
 from handlers.civil_war_admin_config import process_admin_config_response
 from handlers.civil_war import civil_war, civil_war_stats, is_civil_war_trigger, is_civil_war_stats_trigger
 from handlers.civil_war_season2 import process_season2_private_response
@@ -53,8 +52,6 @@ async def message_handler(update: Update, context: ContextTypes) -> None:
     elif (context.user_data.get('state') == 'USER_INFO_EDIT' and update.message.chat.id ==
           context.user_data.get('quiz_chat_id')):
         await edit_user_data(update, context)
-
-    await process_birthday_reminders(update, context)
 
 
 async def username_updater(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from handlers.new_database import new_database
 from handlers.message_handler import message_handler, username_updater
 from handlers.get_users import get_users
 from handlers.add_user import add_user
+from handlers.birthday_reminders import send_daily_birthday_reminders
 from handlers.civil_war_admin_config import civil_war_config, help_admin
 from handlers.civil_war_admin_events import test_civil_war_fail, test_civil_war_mafia, test_civil_war_rare, \
     test_civil_war_rare_fail, test_civil_war_rat, test_civil_war_rat_choice, test_civil_war_win
@@ -92,6 +93,11 @@ def main() -> None:
             send_daily_stats,
             time=datetime.time(hour=6, minute=0, tzinfo=datetime.timezone.utc),
             name="daily_stats",
+        )
+        application.job_queue.run_daily(
+            send_daily_birthday_reminders,
+            time=datetime.time(hour=6, minute=1, tzinfo=datetime.timezone.utc),
+            name="daily_birthday_reminders",
         )
     # Add message handlers. We explicitly exclude command updates from the generic
     # message_handler, otherwise the command message itself (e.g. "/start") would be

--- a/tests/test_birthday_reminders.py
+++ b/tests/test_birthday_reminders.py
@@ -48,25 +48,26 @@ sys.modules.setdefault('telegram', telegram_module)
 sys.modules.setdefault('telegram.error', telegram_error_module)
 sys.modules.setdefault('telegram.ext', telegram_ext_module)
 
-from handlers.birthday_reminders import process_birthday_reminders
+from handlers.birthday_reminders import send_daily_birthday_reminders
 
 
-def build_update():
-    from_user = SimpleNamespace(id=123, name='Tester')
-    chat = SimpleNamespace(id=456, type='supergroup', send_message=AsyncMock())
-    message = SimpleNamespace(reply_text=AsyncMock(), from_user=from_user, chat=chat, message_thread_id=42)
-    return SimpleNamespace(message=message, effective_message=message, effective_user=from_user, effective_chat=chat)
+def build_context(chat_ids=(-456,)):
+    return SimpleNamespace(
+        bot_data={'stats_chat_ids': set(chat_ids)},
+        bot=SimpleNamespace(send_message=AsyncMock()),
+    )
 
 
-def build_context():
-    return SimpleNamespace(user_data={}, chat_data={})
+def add_test_user(db_path, birthday):
+    test_user = create_user({'user_id': 1, 'name': 'Test User', 'tg_username': '@test_user', 'birthday': birthday,
+                             'wishlist_url': 'https://example.com', 'money_gifts': True, 'funny_gifts': True})
+    db.add_user(db_path, test_user)
 
 
 class TestBirthdayReminders(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.db_path = 'users_test.sqlite'
         db.create_database(self.db_path)
-        self.old_db_path = None
 
     def tearDown(self):
         db.clear_database(self.db_path)
@@ -79,54 +80,102 @@ class TestBirthdayReminders(unittest.IsolatedAsyncioTestCase):
 
         return patch('handlers.birthday_reminders.datetime.date', FakeDate)
 
-    async def test_process_resets_advance_flags_outside_window(self):
-        test_user = create_user({'user_id': 1, 'name': 'Test User', 'tg_username': '@test_user', 'birthday': '01.01.2000',
-                                 'wishlist_url': 'https://example.com', 'money_gifts': True, 'funny_gifts': True})
-        db.add_user(self.db_path, test_user)
-        db.update_reminder(self.db_path, 1, '@test_user', 'reminder_14_days')
+    async def test_does_nothing_without_registered_chats(self):
+        add_test_user(self.db_path, '21.04.2000')
+        context = build_context(chat_ids=())
 
-        fake_today = datetime.date(2026, 1, 20)
-        update = build_update()
+        with patch('handlers.birthday_reminders.os.getenv', return_value=self.db_path), \
+                self._patch_today(datetime.date(2026, 4, 21)):
+            await send_daily_birthday_reminders(context)
+
+        context.bot.send_message.assert_not_called()
+        self.assertFalse(db.get_reminder_status(self.db_path, 1, '@test_user', 'birthday_today'))
+
+    async def test_resets_advance_flags_outside_window(self):
+        add_test_user(self.db_path, '01.01.2000')
+        db.update_reminder(self.db_path, 1, '@test_user', 'reminder_14_days')
         context = build_context()
 
         with patch('handlers.birthday_reminders.os.getenv', return_value=self.db_path), \
-                self._patch_today(fake_today):
-            await process_birthday_reminders(update, context)
+                self._patch_today(datetime.date(2026, 1, 20)):
+            await send_daily_birthday_reminders(context)
 
         self.assertFalse(db.get_reminder_status(self.db_path, 1, '@test_user', 'reminder_14_days'))
 
-    async def test_process_does_not_reset_advance_flags_inside_window_across_new_year(self):
-        test_user = create_user({'user_id': 1, 'name': 'Test User', 'tg_username': '@test_user', 'birthday': '14.01.2000',
-                                 'wishlist_url': 'https://example.com', 'money_gifts': True, 'funny_gifts': True})
-        db.add_user(self.db_path, test_user)
+    async def test_does_not_reset_advance_flags_inside_window_across_new_year(self):
+        add_test_user(self.db_path, '14.01.2000')
         db.update_reminder(self.db_path, 1, '@test_user', 'reminder_14_days')
-
-        fake_today = datetime.date(2026, 1, 1)
-        update = build_update()
         context = build_context()
 
         with patch('handlers.birthday_reminders.os.getenv', return_value=self.db_path), \
-                self._patch_today(fake_today):
-            await process_birthday_reminders(update, context)
+                self._patch_today(datetime.date(2026, 1, 1)):
+            await send_daily_birthday_reminders(context)
 
         self.assertTrue(db.get_reminder_status(self.db_path, 1, '@test_user', 'reminder_14_days'))
 
-    async def test_process_keeps_birthday_today_flag_on_birthday(self):
-        test_user = create_user({'user_id': 1, 'name': 'Test User', 'tg_username': '@test_user', 'birthday': '21.04.2000',
-                                 'wishlist_url': 'https://example.com', 'money_gifts': True, 'funny_gifts': True})
-        db.add_user(self.db_path, test_user)
+    async def test_sends_advance_reminder_with_expected_payload(self):
+        add_test_user(self.db_path, '05.05.2000')
+        context = build_context(chat_ids=(-456,))
 
-        fake_today = datetime.date(2026, 4, 21)
-        update = build_update()
+        with patch('handlers.birthday_reminders.os.getenv', return_value=self.db_path), \
+                self._patch_today(datetime.date(2026, 4, 21)):
+            await send_daily_birthday_reminders(context)
+
+        self.assertTrue(db.get_reminder_status(self.db_path, 1, '@test_user', 'reminder_14_days'))
+        context.bot.send_message.assert_awaited_once()
+        kwargs = context.bot.send_message.await_args.kwargs
+        self.assertEqual(kwargs['chat_id'], -456)
+        self.assertIn('Скоро день рождения', kwargs['text'])
+        self.assertEqual(kwargs['parse_mode'], 'MarkdownV2')
+
+    async def test_sends_birthday_greeting_and_sets_flag(self):
+        add_test_user(self.db_path, '21.04.2000')
+        context = build_context(chat_ids=(-456,))
+
+        with patch('handlers.birthday_reminders.os.getenv', return_value=self.db_path), \
+                self._patch_today(datetime.date(2026, 4, 21)):
+            await send_daily_birthday_reminders(context)
+
+        self.assertTrue(db.get_reminder_status(self.db_path, 1, '@test_user', 'birthday_today'))
+        context.bot.send_message.assert_awaited_once()
+        kwargs = context.bot.send_message.await_args.kwargs
+        self.assertEqual(kwargs['chat_id'], -456)
+        self.assertIn('С ДНЕМ РОЖДЕНИЯ', kwargs['text'])
+        self.assertEqual(kwargs['parse_mode'], 'MarkdownV2')
+
+    async def test_broadcasts_to_every_registered_chat_exactly_once(self):
+        add_test_user(self.db_path, '21.04.2000')
+        context = build_context(chat_ids=(-100, -200, -300))
+
+        with patch('handlers.birthday_reminders.os.getenv', return_value=self.db_path), \
+                self._patch_today(datetime.date(2026, 4, 21)):
+            await send_daily_birthday_reminders(context)
+
+        self.assertEqual(context.bot.send_message.await_count, 3)
+        sent_chat_ids = {call.kwargs['chat_id'] for call in context.bot.send_message.await_args_list}
+        self.assertEqual(sent_chat_ids, {-100, -200, -300})
+        self.assertTrue(db.get_reminder_status(self.db_path, 1, '@test_user', 'birthday_today'))
+
+    async def test_does_not_resend_already_delivered_reminder(self):
+        add_test_user(self.db_path, '21.04.2000')
+        db.update_reminder(self.db_path, 1, '@test_user', 'birthday_today')
         context = build_context()
 
         with patch('handlers.birthday_reminders.os.getenv', return_value=self.db_path), \
-                self._patch_today(fake_today):
-            await process_birthday_reminders(update, context)
+                self._patch_today(datetime.date(2026, 4, 21)):
+            await send_daily_birthday_reminders(context)
 
-        self.assertTrue(db.get_reminder_status(self.db_path, 1, '@test_user', 'birthday_today'))
-        update.effective_chat.send_message.assert_awaited_once()
-        self.assertNotIn('message_thread_id', update.effective_chat.send_message.await_args.kwargs)
+        context.bot.send_message.assert_not_called()
+
+    async def test_ignores_chat_ids_above_zero(self):
+        add_test_user(self.db_path, '21.04.2000')
+        context = build_context(chat_ids=(123,))  # private chat id, should never end up here, but defends anyway
+
+        with patch('handlers.birthday_reminders.os.getenv', return_value=self.db_path), \
+                self._patch_today(datetime.date(2026, 4, 21)):
+            await send_daily_birthday_reminders(context)
+
+        context.bot.send_message.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changes:
- Add a scheduler configuration for birthday reminder checks
- Trigger reminder processing automatically at the configured interval
- Integrate the scheduler with the existing reminder workflow
- Improve automation of birthday notification handling
Related issue: #7